### PR TITLE
Fix segmentation fault error when an empty list of hosts is passed in…

### DIFF
--- a/src/aerospike/main/ext_aerospike.cpp
+++ b/src/aerospike/main/ext_aerospike.cpp
@@ -103,13 +103,15 @@ namespace HPHP {
      * Which is host_entry => address:port.
      ************************************************************************************
      */
-#define CREATE_NEW_ALIAS(iter_hosts)                                         \
-    alias_to_search = (char*) malloc(strlen(config.hosts[iter_hosts].addr) + \
-            MAX_PORT_SIZE + 1);                                              \
-    strcpy(alias_to_search, config.hosts[iter_hosts].addr);                  \
-    strcat(alias_to_search, ":");                                            \
-    sprintf(port , "%d", config.hosts[iter_hosts].port);                     \
-    strcat(alias_to_search, port);
+#define CREATE_NEW_ALIAS(iter_hosts)                                             \
+    if (config.hosts_size) {                                                     \
+        alias_to_search = (char*) malloc(strlen(config.hosts[iter_hosts].addr) + \
+                MAX_PORT_SIZE + 1);                                              \
+        strcpy(alias_to_search, config.hosts[iter_hosts].addr);                  \
+        strcat(alias_to_search, ":");                                            \
+        sprintf(port , "%d", config.hosts[iter_hosts].port);                     \
+        strcat(alias_to_search, port);                                           \
+    }
 
     /*
      ************************************************************************************


### PR DESCRIPTION
… the constructor of Aerospike class and persistent connections are enabled

If you send an empty list of hosts for Aerospike to connect to, then the following segmentation fault will happen:

(gdb) bt
#0  strlen () at ../sysdeps/x86_64/strlen.S:106
#1  0x00007fffe5b94900 in HPHP::Aerospike::configure_connection (this=0x7fffe04c1118, config=..., error=...) at /dev/aerospike-client-hhvm/src/aerospike/main/ext_aerospike.cpp:210
#2  0x00007fffe5b94cab in HPHP::c_Aerospike_ni___construct (this_=0x7fffe04c1580, php_config=..., persistent_connection=true, options=...)

```
at /dev/aerospike-client-hhvm/src/aerospike/main/ext_aerospike.cpp:263
```
#3  0x000000000107b8a3 in void HPHP::Native::callFunc<false>(HPHP::Func const_, void_, HPHP::TypedValue*, int, HPHP::TypedValue&) ()
#4  0x000000000107bce9 in HPHP::TypedValue\* HPHP::Native::methodWrapper<false>(HPHP::ActRec*) ()
#5  0x000000000267c537 in unsigned char\* HPHP::dispatchImpl<false>() ()
#6  0x0000000000f682dd in HPHP::enterVMAtFunc(HPHP::ActRec_, HPHP::StackArgsState, HPHP::VarEnv_) ()
#7  0x00000000026a5c32 in HPHP::ExecutionContext::invokeFunc(HPHP::TypedValue_, HPHP::Func const_, HPHP::Variant const&, HPHP::ObjectData_, HPHP::Class_, HPHP::VarEnv_, HPHP::StringData_, HPHP::ExecutionContext::InvokeFlags) ()
#8  0x00000000026e702d in HPHP::ExecutionContext::invokeUnit(HPHP::TypedValue_, HPHP::Unit const_) ()
#9  0x0000000000bd76f5 in HPHP::include_impl_invoke(HPHP::String const&, bool, char const*) ()
#10 0x0000000000cf9eb4 in HPHP::hphp_invoke(HPHP::ExecutionContext*, std::string const&, bool, HPHP::Array const&, HPHP::VRefParamValue const&, std::string const&, std::string const&, bool&, std::string&, bool, bool, bool) ()
#11 0x0000000000e0df4d in HPHP::HttpRequestHandler::executePHPRequest(HPHP::Transport*, HPHP::RequestURI&, HPHP::SourceRootInfo&, bool) ()
#12 0x0000000000e1004e in HPHP::HttpRequestHandler::handleRequest(HPHP::Transport*) ()
#13 0x0000000000e8197a in HPHP::ServerWorkerstd::shared_ptr<HPHP::FastCGIJob, HPHP::FastCGITransportTraits>::doJobImpl(std::shared_ptrHPHP::FastCGIJob, bool) ()
#14 0x0000000000e81eee in HPHP::ServerWorkerstd::shared_ptr<HPHP::FastCGIJob, HPHP::FastCGITransportTraits>::doJob(std::shared_ptrHPHP::FastCGIJob) ()
#15 0x0000000000e804a6 in HPHP::JobQueueWorkerstd::shared_ptr<HPHP::FastCGIJob, HPHP::Server*, true, false, HPHP::JobQueueDropVMStack>::start() ()
#16 0x0000000001f2c247 in HPHP::AsyncFuncImpl::ThreadFunc(void*) ()
#17 0x0000000000c4cfa7 in HPHP::start_routine_wrapper(void*) ()
#18 0x00007ffff1331182 in start_thread (arg=0x7fffdabff700) at pthread_create.c:312
#19 0x00007ffff083e47d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111

This pull request is fixing the segmentation fault by checking if there is at least one host in the config
