### PR TITLE
Make last-error value and mutex private

### DIFF
--- a/src/aerospike/include/ext_aerospike.h
+++ b/src/aerospike/include/ext_aerospike.h
@@ -92,8 +92,6 @@ namespace HPHP {
             bool is_connected = false;
             bool is_persistent = false;
             int16_t serializer_value = SERIALIZER_PHP;
-            as_error latest_error;
-            pthread_rwlock_t latest_error_mutex;
 
             //static ObjectData* serializer;
             static Variant serializer;
@@ -107,7 +105,13 @@ namespace HPHP {
 
             as_status configure_connection(as_config& config, as_error& error);
 
+            void setError(const as_error& error);
+            const as_error& getError() { return latest_error; }
+
         private:
+            as_error latest_error;
+            pthread_rwlock_t latest_error_mutex;
+
             void create_new_host_entry(as_config& config, as_error& error);
             void iterate_hosts_add_entry(as_config& config, int matched_host_id);
     };

--- a/src/aerospike/main/ext_aerospike.cpp
+++ b/src/aerospike/main/ext_aerospike.cpp
@@ -232,6 +232,21 @@ namespace HPHP {
 
     /*
      ************************************************************************************
+     * Updates the "lastest_error" field in the object's NativeData
+     * May block while waiting for shared mutex
+     ************************************************************************************
+     */
+    void Aerospike::setError(const as_error& error) {
+        pthread_rwlock_wrlock(&latest_error_mutex);
+        /* https://github.com/aerospike/aerospike-client-c/pull/33
+         * Obviates the need for this const cast.
+         */
+        as_error_copy(&latest_error, const_cast<as_error*>(&error));
+        pthread_rwlock_unlock(&latest_error_mutex);
+    }
+
+    /*
+     ************************************************************************************
      * Definitions of Native methods in PHP Aerospike class declared in
      * ext_aerospike.h and specified in ext_aerospike.php
      ************************************************************************************
@@ -275,9 +290,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
     }
     /* }}} */
 
@@ -330,9 +343,7 @@ namespace HPHP {
             data->is_connected = false;
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -383,9 +394,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -467,9 +476,7 @@ namespace HPHP {
         if (key_initialized) {
             as_key_destroy(&key);
         }
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -510,9 +517,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -543,9 +548,7 @@ namespace HPHP {
                         &error, &info_policy,ns.toString().c_str(), name.toString().c_str());
         }
         
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -602,9 +605,7 @@ namespace HPHP {
         if (key_initialized) {
             as_key_destroy(&key);
         }
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -647,9 +648,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -707,9 +706,7 @@ namespace HPHP {
         if (key_initialized) {
             as_key_destroy(&key);
         }
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -751,9 +748,7 @@ namespace HPHP {
         if (key_initialized) {
             as_key_destroy(&key);
         }
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -804,9 +799,7 @@ namespace HPHP {
         if (key_initialized) {
             as_key_destroy(&key);
         }
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -852,9 +845,7 @@ namespace HPHP {
         if (key_initialized) {
             as_key_destroy(&key);
         }
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -896,9 +887,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -952,9 +941,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -986,9 +973,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -1024,9 +1009,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -1062,9 +1045,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
         return error.code;
     }
 
@@ -1108,10 +1089,7 @@ namespace HPHP {
             as_key_destroy(&key);
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
-
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -1158,10 +1136,7 @@ namespace HPHP {
             as_scan_destroy(&scan);
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
-
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -1223,10 +1198,7 @@ namespace HPHP {
             as_scan_destroy(&scan);
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
-
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -1271,10 +1243,7 @@ namespace HPHP {
             }
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
-
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -1399,10 +1368,7 @@ namespace HPHP {
             as_query_destroy(&query);
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
-
+        data->setError(error);
         return error.code;
     }
     /* }}} */
@@ -1452,9 +1418,7 @@ namespace HPHP {
             as_query_destroy(&query);
         }
 
-        pthread_rwlock_wrlock(&data->latest_error_mutex);
-        as_error_copy(&data->latest_error, &error);
-        pthread_rwlock_unlock(&data->latest_error_mutex);
+        data->setError(error);
 
         result_variant = aggregate_array;
         result_variant.releaseForSweep();
@@ -1467,8 +1431,7 @@ namespace HPHP {
        Displays the error message associated with the last operation */
     int64_t HHVM_METHOD(Aerospike, errorno)
     {
-        auto                data = Native::data<Aerospike>(this_);
-        return data->latest_error.code;
+        return Native::data<Aerospike>(this_)->getError().code;
     }
     /* }}} */
 
@@ -1476,8 +1439,7 @@ namespace HPHP {
        Displays the status code associated with the last operation */
     String HHVM_METHOD(Aerospike, error)
     {
-        auto                data = Native::data<Aerospike>(this_);
-        return data->latest_error.message;
+        return Native::data<Aerospike>(this_)->getError().message;
     }
     /* }}} */
 


### PR DESCRIPTION
Guard against accidental non-locked access of last_error
and reduce the copypasta happening throughout the extension.

Basically, all these functions do: lock-copy-unlock,
so make that a single call.
