### PR TITLE
Replace CREATE_NEW_ALIAS macro with an inline

### DIFF
--- a/src/aerospike/main/ext_aerospike.cpp
+++ b/src/aerospike/main/ext_aerospike.cpp
@@ -105,6 +105,9 @@ namespace HPHP {
      */
 namespace {
     inline char* create_new_alias(const as_config& config, int iter_hosts) {
+        assert(iter_hosts >= 0);
+        assert(iter_hosts < config.hosts_size);
+
         auto const host = config.hosts[iter_hosts];
         auto const addr_len = strlen(host.addr);
         auto const ret_size = addr_len + 1 + MAX_PORT_SIZE + 1;
@@ -209,7 +212,7 @@ namespace {
                 }
             }
 
-            alias_to_search = create_new_alias(config, 0);
+            alias_to_search = config.hosts_size ? create_new_alias(config, 0) : NULL;
             create_new_host_entry(config, error);
             if (error.code == AEROSPIKE_OK) {
                 as_ref_p->ref_host_entry++;


### PR DESCRIPTION
Using a macro here has disadvantages compared to an inline.
- Opaque errors: Line number only shows callsite,
  not position in implementation
- Local variable declaration: 'port' and 'alias_to_search'
  have to be declared in the callsite, but it's not visually
  obvious where they're populated or how.
- Source variable naming: 'config' is similarly expected as above.

I also replaced the potentially unsafe usages of strcpy/strcat
with a call to snprintf bounded by the allocation size.
