### PR TITLE
Fix a thread-safety bug in (de)serializer logic

### DIFF
--- a/src/aerospike/main/conversions.cpp
+++ b/src/aerospike/main/conversions.cpp
@@ -287,8 +287,8 @@ namespace HPHP {
                 break;
             case SERIALIZER_USER:
                 *bytes_p = static_pool.get_as_bytes();
-                if (Aerospike::is_serializer_registered) {
-                    execute_user_callback(Aerospike::serializer, bytes_p, value_to_serialize,
+                if (Aerospike::hasSerializer()) {
+                    execute_user_callback(Aerospike::serializer(), bytes_p, value_to_serialize,
                             true, error);
                     if (error.code == AEROSPIKE_OK) {
                         set_as_bytes(bytes_p, value_to_serialize.toString(), AS_BYTES_BLOB, error);
@@ -335,8 +335,8 @@ namespace HPHP {
                 break;
             case AS_BYTES_BLOB:
                 {
-                    if (Aerospike::is_deserializer_registered) {
-                        execute_user_callback(Aerospike::deserializer, &bytes_p, php_value,
+                    if (Aerospike::hasDeserializer()) {
+                        execute_user_callback(Aerospike::deserializer(), &bytes_p, php_value,
                                 false, error);
                         if (error.code != AEROSPIKE_OK) {
                             break;

--- a/src/aerospike/main/ext_aerospike.cpp
+++ b/src/aerospike/main/ext_aerospike.cpp
@@ -28,10 +28,7 @@ namespace HPHP {
     /*
      * Static member's definition
      */
-    Variant Aerospike::serializer;
-    Variant Aerospike::deserializer;
-    int Aerospike::is_serializer_registered = 0;
-    int Aerospike::is_deserializer_registered = 0;
+    IMPLEMENT_REQUEST_LOCAL(AerospikeRequestLocals, Aerospike::locals);
 
     /*
      ************************************************************************************
@@ -399,9 +396,7 @@ namespace HPHP {
             return false;
         }
 
-        Aerospike::serializer = callback;
-        Aerospike::is_serializer_registered = 1;
-
+        Aerospike::setSerializer(callback);
         return true;
     }
     /* }}} */
@@ -415,9 +410,7 @@ namespace HPHP {
             return false;
         }
 
-        Aerospike::deserializer = callback;
-        Aerospike::is_deserializer_registered = 1;
-
+        Aerospike::setDeserializer(callback);
         return true;
     }
     /* }}} */
@@ -1594,8 +1587,6 @@ namespace HPHP {
             {
                 as_error error;
                 aerospike_ref *map_entry = NULL;
-                Aerospike::serializer.releaseForSweep();
-                Aerospike::deserializer.releaseForSweep();
 
                 as_error_init(&error);
 


### PR DESCRIPTION
Aerospike::serialzier/deserializer were declred as true globals
which means that one thread could easily clobber over another's setting.
The .releaseForSweep() was also happening in the wrong phase to save
us from a potential crash when the request sweep happens.
